### PR TITLE
Support building of docker images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.gitignore
+GPL.txt
+LICENSE.txt
+Vagrantfile
+solr4/
+sample/
+vagrant/
+viewers/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,68 @@
+FROM python:2.7
+
+LABEL org.label-schema.name="MDID" \
+      org.label-schema.description="Basic intallation of MDID" \
+      org.label-schema.schema-version="1.0"
+
+ENV PYTHONUNBUFFERED=1
+
+HEALTHCHECK CMD curl -f http://localhost:8080/ || exit 1
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends libjpeg-dev libfreetype6-dev libldap2-dev \
+       autoconf automake build-essential libass-dev libtheora-dev libtool libvorbis-dev pkg-config \
+       texinfo zlib1g-dev yasm libx264-dev libmp3lame-dev libsasl2-dev unixodbc-dev \
+    && useradd mdid \
+    && rm -Rf /var/lib/apt/lists
+
+### Install compiled libraries first so repackagaing MDID itself goes a little faster
+# Install GFX
+ADD http://www.swftools.org/swftools-0.9.2.tar.gz /opt/tools/swftools-0.9.2.tar.gz
+RUN cd /opt/tools \
+    && tar xzf swftools-0.9.2.tar.gz \
+    && cd swftools-0.9.2 \
+    && ./configure \
+    && make -j4
+
+# Install FFMPEG
+ADD http://ffmpeg.org/releases/ffmpeg-snapshot.tar.bz2 /opt/ffmpeg/ffmpeg-snapshot.tar.bz2
+RUN cd /opt/ffmpeg \
+    && tar xjf ffmpeg-snapshot.tar.bz2 \
+    && cd ffmpeg \
+    && PATH="/opt/ffmpeg/bin:$PATH" \
+    PKG_CONFIG_PATH="/opt/ffmpeg/lib/pkgconfig" \
+    ./configure \
+    --prefix="/opt/ffmpeg" \
+    --pkg-config-flags="--static" \
+    --extra-cflags="-I/opt/ffmpeg/include" \
+    --extra-ldflags="-L/opt/ffmpeg/lib" \
+    --bindir="/opt/ffmpeg/bin" \
+    --enable-gpl \
+    --enable-libass \
+    --enable-libfreetype \
+    --enable-libmp3lame \
+    --enable-libtheora \
+    --enable-libvorbis \
+    --enable-libx264 \
+    && PATH="/opt/ffmpeg/bin:$PATH" make -j4 install \
+    && cp /opt/ffmpeg/bin/* /usr/local/bin \
+    && cd .. \
+    && rm -Rf ffmpeg-snapshot.tar.bz2 ffmpeg
+
+# Actually start installing MDID itself
+COPY . /opt/mdid
+WORKDIR /opt/mdid
+
+ENV DJANGO_SETTINGS_MODULE="rooibos_settings.local_settings"
+
+# Install python packages and cleanup
+RUN pip install --no-cache-dir --allow-external --upgrade -r requirements.txt \
+    && mkdir /opt/mdid/log /opt/mdid/scratch /opt/mdid/storage /opt/mdid/static \
+    && mv rooibos_settings/base_docker.py rooibos_settings/base.py \
+    && mv rooibos_settings/docker_template.py rooibos_settings/local_settings.py \
+    && python manage.py collectstatic --noinput \
+    && apt-get purge -y build-essential yasm autoconf automake gcc g++ \
+    && apt-get autoremove -y
+
+EXPOSE 8080
+CMD ["gunicorn", "-b", "0.0.0.0:8080", "rooibos.wsgi:application", "--log-config", "docker/gunicorn-logging.conf"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,66 @@
+mdid-docker
+===========
+
+Docker can be used to run MDID and its dependencies (e.g. rabbitmq, memcached,
+etc.).
+
+Images are published on the docker hub as
+[wmit/mdid](https://hub.docker.com/r/wmit/mdid/) and
+[wmit/solr4/mdid](https://hub.docker.com/r/wmit/solr4-mdid/)
+
+## MDID Configuration
+
+Settings outside of database connection information can be provided by
+creating a new image, or by using the `docker config` tool introduced in Docker
+17.06.
+
+A simple overlay Dockerfile will look like
+```
+FROM wmit/mdid
+
+COPY local_settings.py /opt/mdid/rooibos_settings/local_settings.py
+```
+
+In a perfect world, images are built automatically from version control, without
+passwords or other secrets inside the image. To help make that a reality, MDID
+supports providing database secrets in a few different ways.
+
+### Environment Variables
+
+MDID in Docker will check for environment variables named `DB_NAME`, `DB_USER`,
+`DB_PASSWORD`, and `DB_HOST` for the information. The method is discouraged as
+environment information is rarely treated as secret by applications, but is
+supported because it's often easier to use during development.
+
+If `DB_PASSWORD` is set to a valid file path, the contents of that file will
+be used as the database password.
+
+### Docker Secrets (swarm mode)
+
+If the environment variable `DB_PASSWORD` or the PASSWORD setting in
+`config.ini` is set to a valid file path, the contents of that file will be used
+as the database password.
+
+## Building Images
+
+The only images that are built from source are MDID and solr. They can
+be build using [docker-compose](https://docs.docker.com/compose/). To build the
+images using your code run `docker-compose build` from inside this directory.
+
+## Running
+
+To run MDID in a test environment, run the `docker-start.sh` script. Startup
+can take around 40 seconds or so, 35 of which is waiting for MySQL to become
+available.
+
+## Swarm Mode
+
+In addition to supporting docker secrets, the `stack.yml` file contains a file
+ready to be used in conjunction with `docker stack deploy...` to get a system
+ready for production. The stack ready compose file doesn't include a database
+since persistent data in Swarm can still be challenging.
+
+## Known Issues
+
+cron jobs aren't run automatically in Docker and aren't accounted for in any of
+the examples.

--- a/docker/config.ini
+++ b/docker/config.ini
@@ -1,0 +1,16 @@
+; This configuration file is only used in Docker, and is only meant to store
+; secrets (passwords and associated data). Other configuration is in
+; rooibos_settings/docker.py
+;
+; In production this should be supplied using docker secrets
+
+[SECRET]
+SECRET_KEY: e#!poDuIJ}N,".K=H:T/4z5POb;Gl/N6$6a&,(DRAHUF5c",_p
+
+[DATABASE]
+ENGINE: django.db.backends.mysql
+NAME: mdid
+USER: mdid
+PASSWORD: supersecretpassword
+HOST: database
+PORT: 3306

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,49 @@
+version: '3.2'
+
+services:
+  mdid:
+    build: ../.
+    image: wmit/mdid:3.2
+    ports:
+      - target: 8080
+        published: 8080
+        protocol: tcp
+        mode: ingress
+    depends_on:
+      - solr
+      - rabbitmq
+      - memcached
+      - database
+    environment:
+      DB_USER: mdid
+      DB_PASSWORD: supersecretpassword
+      DB_NAME: mdid
+  worker:
+    build: ../.
+    image: wmit/mdid:3.2
+    command: python manage.py runworkers
+    healthcheck:
+      disable: true
+    depends_on:
+      - solr
+      - rabbitmq
+      - memcached
+      - database
+  solr:
+    build: ../solr4/
+    image: wmit/solr4-mdid
+  rabbitmq:
+    image: rabbitmq:3.6-alpine
+  memcached:
+    image: memcached:1.4-alpine
+    command: memcached -m 128
+  database:
+    image: mysql:5.7
+    healthcheck:
+      test: mysql -umdid -psupersecretpassword mdid -e'SELECT 1'
+    environment:
+      MYSQL_DATABASE: mdid
+      MYSQL_USER: mdid
+      MYSQL_PASSWORD: supersecretpassword
+      MYSQL_RANDOM_ROOT_PASSWORD: "yes"
+      MYSQL_ONETIME_PASSWORD: "yes"

--- a/docker/docker-start.sh
+++ b/docker/docker-start.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+docker-compose up -d database
+sleep 35
+docker run --network docker_default wmit/mdid:3.2 python manage.py syncdb --noinput
+docker run --network docker_default wmit/mdid:3.2 python manage.py migrate
+docker-compose up -d

--- a/docker/gunicorn-logging.conf
+++ b/docker/gunicorn-logging.conf
@@ -1,0 +1,31 @@
+[loggers]
+keys=root, gunicorn.error, gunicorn.access
+
+[handlers]
+keys=console
+
+[formatters]
+keys=formatter
+
+[logger_root]
+level=INFO
+handlers=console
+
+[logger_gunicorn.error]
+level=WARN
+handlers=console
+propagate=0
+qualname=gunicorn.error
+
+[logger_gunicorn.access]
+class=StreamHandler
+handlers=console
+propagate=0
+qualname=gunicorn.access
+
+[handler_console]
+class=StreamHandler
+args=(sys.stdout, )
+
+[formatter_formatter]
+format=%(asctime)s %(name)-12s %(levelname)-8s %(message)s

--- a/docker/stack.yml
+++ b/docker/stack.yml
@@ -1,0 +1,74 @@
+# This stack file is designed to be deployed using
+# docker stack deploy -c stack.yml mdid
+#
+# A secret named mdid.db_password.1 should already be created in your swarm
+# cluster. Be sure to go through this file to see what should change in your
+# environment.
+
+version: '3.2'
+
+# There's a secret stored in Docker, but we don't keep it here (it's external)
+secrets:
+  mdid.db_password.1:
+    external: true
+
+# Possibly use NFS for media storage
+# volumes:
+#   media:
+#     driver: local
+#     driver_opts:
+#       type: nfs
+#       o: addr=NFS_server.example.edu,nfsvers=3
+#       device: ":/mdid/media"
+
+services:
+  mdid:
+    image: wmit/mdid:3.2
+    # volumes:
+    # - type: volume
+    #   source: media
+    #   target: /var/mdid/media
+    #   read_only: false
+    secrets:
+    - source: mdid.db_password.1
+      target: db_password
+      mode: 0444
+    environment:
+      DB_NAME: mdid
+      DB_USER: mdid
+      DB_PASSWORD: /run/secrets/db_password
+      DB_HOST: databaseserver.example.edu
+    deploy:
+      replicas: 1
+
+  worker:
+    build: .
+    image: wmit/mdid:3.2
+    command: python manage.py runworkers
+    healthcheck:
+      disable: true
+    # volumes:
+    # - type: volume
+    #   source: media
+    #   target: /var/mdid/media
+    #   read_only: false
+    secrets:
+    - source: mdid.db_password.1
+      target: db_password
+      mode: 0444
+    environment:
+      DB_NAME: mdid
+      DB_USER: mdid
+      DB_PASSWORD: /run/secrets/db_password
+      DB_HOST: databaseserver.example.edu
+
+  solr:
+    build: solr4/
+    image: wmit/solr4-mdid
+
+  rabbitmq:
+    image: rabbitmq:3.6-alpine
+
+  memcached:
+    image: memcached:1.4-alpine
+    command: memcached -m 128

--- a/rooibos_settings/base_docker.py
+++ b/rooibos_settings/base_docker.py
@@ -1,0 +1,544 @@
+# DON'T PUT ANY LOCALIZED SETTINGS OR SECRETS IN THIS FILE
+# they should go in a custom file instead based on settings/template.py
+
+import os
+import sys
+import re
+from ConfigParser import RawConfigParser
+
+
+install_dir = os.path.normpath(os.path.join(os.path.dirname(__file__), '..'))
+
+if install_dir not in sys.path:
+    sys.path.insert(0, install_dir)
+
+
+DEBUG = False
+TEMPLATE_DEBUG = DEBUG
+
+# Build paths inside the project like this: os.path.join(BASE_DIR, ...)
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+config = RawConfigParser()
+config.read(os.getenv('CONFIG_FILE', BASE_DIR + '/docker/config.ini'))
+
+# Make this unique, and don't share it with anybody.
+SECRET_KEY = config.get('SECRET', 'SECRET_KEY')
+
+# Add the hostname of your server, or keep '*' to allow all host names
+ALLOWED_HOSTS = ['*']
+
+# If the value of DB_PASSWORD or the PASSWORD setting in the config file
+# is a valid file path, use the contents of the file as the database password,
+# otherwise use the value provided.
+db_password = os.getenv('DB_PASSWORD', config.get('DATABASE', 'PASSWORD'))
+if os.path.isfile(db_password):
+    with open(db_password, 'r') as password_file:
+        db_password = password_file.read()
+
+# Database configuration
+# If environment variables aren't set then look in the config file
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.mysql',
+        'NAME': os.getenv('DB_NAME', config.get('DATABASE', 'NAME')),
+        'USER': os.getenv('DB_USER', config.get('DATABASE', 'USER')),
+        'PASSWORD': db_password,
+        'HOST': os.getenv('DB_HOST', config.get('DATABASE', 'HOST')),
+        'PORT': '',
+        'OPTIONS': {
+            'use_unicode': True,
+            'charset': 'utf8',
+        },
+    }
+}
+
+
+RABBITMQ_OPTIONS = {
+    'host': 'rabbitmq',
+}
+
+# Local time zone for this installation. Choices can be found here:
+# http://en.wikipedia.org/wiki/List_of_tz_zones_by_name
+# although not all choices may be available on all operating systems.
+# If running in a Windows environment this must be set to the same as your
+# system time zone.
+TIME_ZONE = 'America/New_York'
+
+SOLR_URL = 'http://solr:8983/solr/mdid'
+SOLR_RECORD_INDEXER = None
+SOLR_RECORD_PRE_INDEXER = None
+
+
+# Theme colors for use in CSS
+PRIMARY_COLOR = "rgb(152, 189, 198)"
+SECONDARY_COLOR = "rgb(118, 147, 154)"
+
+# Needed to enable compression JS and CSS files
+COMPRESS = True
+COMPRESS_VERBOSE = True
+
+
+STATIC_ROOT = os.path.join(install_dir, 'static')
+
+SCRATCH_DIR = os.path.join(install_dir, 'scratch')
+AUTO_STORAGE_DIR = os.path.join(install_dir, 'autostorage')
+
+
+# URL prefix for admin media -- CSS, JavaScript and images. Make sure to use a
+# trailing slash.
+# Examples: "http://foo.com/media/", "/media/".
+ADMIN_MEDIA_PREFIX = '/static/admin/'
+
+
+# Language code for this installation. All choices can be found here:
+# http://www.i18nguy.com/unicode/language-identifiers.html
+LANGUAGE_CODE = 'en-us'
+
+DEFAULT_LANGUAGE = 'en-us'
+
+SITE_ID = 1
+
+# If you set this to False, Django will make some optimizations so as not
+# to load the internationalization machinery.
+USE_I18N = False
+
+USE_ETAGS = False
+
+# When set to True, may cause problems with basket functionality
+SESSION_SAVE_EVERY_REQUEST = False
+
+
+LOGIN_URL = '/login/'
+LOGIN_REDIRECT_URL = '/'
+LOGOUT_URL = '/'
+
+
+# Absolute path to the directory that holds media.
+# Example: "/home/media/media.lawrence.com/"
+MEDIA_ROOT = ''
+
+# URL that handles the media served from MEDIA_ROOT. Make sure to use a
+# trailing slash if there is a path component (optional in other cases).
+# Examples: "http://media.lawrence.com", "http://example.com/media/"
+MEDIA_URL = '/media-unused/'
+
+# List of callables that know how to import templates from various sources.
+TEMPLATE_LOADERS = (
+    'django.template.loaders.filesystem.Loader',
+    'django.template.loaders.app_directories.Loader',
+)
+
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'APP_DIRS': True,
+        'DIRS': [
+            os.path.join(install_dir, 'rooibos', 'templates'),
+        ],
+        'OPTIONS': {
+            'context_processors': (
+                'django.contrib.auth.context_processors.auth',
+                'django.template.context_processors.debug',
+                'django.template.context_processors.media',
+                'django.template.context_processors.request',
+                'django.contrib.messages.context_processors.messages',
+                "rooibos.context_processors.settings",
+                "rooibos.context_processors.selected_records",
+                "rooibos.context_processors.current_presentation",
+            )
+        }
+    },
+]
+
+MIDDLEWARE_CLASSES = (
+    'django.middleware.http.ConditionalGetMiddleware',
+    'rooibos.middleware.Middleware',
+    'rooibos.help.middleware.PageHelp',
+    'ssl_redirect.middleware.SSLRedirectMiddleware',
+    'rooibos.middleware.RemoveSSLArgMiddleware',
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.middleware.common.CommonMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
+    'rooibos.api.middleware.CookielessSessionMiddleware',
+    'django.contrib.flatpages.middleware.FlatpageFallbackMiddleware',
+    'rooibos.ui.middleware.PageTitles',
+    'pagination.middleware.PaginationMiddleware',
+    'django.contrib.redirects.middleware.RedirectFallbackMiddleware',
+    'rooibos.storage.middleware.StorageOnStart',
+    'rooibos.access.middleware.AccessOnStart',
+    'rooibos.data.middleware.DataOnStart',
+    'rooibos.middleware.HistoryMiddleware',
+    'rooibos.access.middleware.AnonymousIpGroupMembershipMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+    'rooibos.auth.middleware.BasicAuthenticationMiddleware',
+)
+
+
+ROOT_URLCONF = 'rooibos.urls'
+
+INSTALLED_APPS = (
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
+    'django.contrib.sessions',
+    'django.contrib.sites',
+    'django.contrib.flatpages',
+    'django.contrib.admin',
+    'django.contrib.humanize',
+    'django_comments',
+    'django.contrib.redirects',
+    'django.contrib.staticfiles',
+    'django.contrib.messages',
+    'django_extensions',
+    'tagging',
+    'rooibos.data',
+    'rooibos.migration',
+    'rooibos.util',
+    'rooibos.access',
+    'rooibos.solr',
+    'rooibos.storage',
+    'rooibos.legacy',
+    'rooibos.ui',
+    'rooibos.viewers',
+    'rooibos.help',
+    'rooibos.presentation',
+    'rooibos.statistics',
+    'rooibos.federatedsearch',
+    'rooibos.federatedsearch.artstor',
+    'rooibos.federatedsearch.flickr',
+    'rooibos.federatedsearch.shared',
+    'rooibos.workers',
+    'rooibos.userprofile',
+    'rooibos.mediaviewer',
+    'rooibos.megazine',
+    'rooibos.groupmanager',
+    'rooibos.pdfviewer',
+    'rooibos.pptexport',
+    'rooibos.works',
+    'pagination',
+    'impersonate',
+    'compressor',
+)
+
+
+STORAGE_SYSTEMS = {
+    'local': 'rooibos.storage.localfs.LocalFileSystemStorageSystem',
+    'online': 'rooibos.storage.online.OnlineStorageSystem',
+    'pseudostreaming':
+        'rooibos.storage.pseudostreaming.PseudoStreamingStorageSystem',
+    's3': 'rooibos.storage.s3.S3StorageSystem',
+}
+
+GROUP_MANAGERS = {
+}
+
+
+WEBSERVICE_NAMESPACE = "http://mdid.jmu.edu/webservices"
+
+# Methods to be called after a user is successfully authenticated
+# using an external backend (LDAP, IMAP, POP).
+# Must take two parameters:
+#   user object
+#   dict of string->list/tuple pairs (may be None or empty)
+# Returns:
+#   True: login continues
+#   False: login rejected, try additional login backends if available
+LOGIN_CHECKS = (
+    'rooibos.access.models.update_membership_by_attributes',
+)
+
+STATICFILES_DIRS = [
+    os.path.join(install_dir, 'rooibos', 'static'),
+]
+
+STATICFILES_FINDERS = (
+    'django.contrib.staticfiles.finders.FileSystemFinder',
+    'django.contrib.staticfiles.finders.AppDirectoriesFinder',
+    'compressor.finders.CompressorFinder',
+)
+
+STATIC_URL = '/static/'
+
+
+FFMPEG_EXECUTABLE = '/usr/local/bin/ffmpeg'
+
+PDF_PAGESIZE = 'letter'  # 'A4'
+
+SHOW_FRONTPAGE_LOGIN = "yes"
+
+MASTER_TEMPLATE = 'master_root.html'
+
+
+ARTSTOR_GATEWAY = None
+
+
+LOGO_URL = None
+FAVICON_URL = None
+COPYRIGHT = None
+TITLE = None
+
+HIDE_SHOWCASES = False
+
+
+PPTEXPORT_WIDTH = 800
+PPTEXPORT_HEIGHT = 600
+
+
+PRIMARY_COLOR = "rgb(152, 189, 198)"
+SECONDARY_COLOR = "rgb(118, 147, 154)"
+
+
+COMPACT_METADATA_VIEW = False
+
+WORKS = {
+    'EXPLORE_MENU': False,
+    'SEARCH_BOX': False,
+}
+
+
+FLICKR_KEY = ''
+FLICKR_SECRET = ''
+
+
+CUSTOM_TRACKER_HTML = ""
+
+SHOW_FRONTPAGE_LOGIN = 'yes'
+
+
+# The Megazine viewer is using a third party component that has commercial
+# licensing requirements.  To enable the component you need to enter your
+# license key, which is available for free for educational institutions.
+# See static/megazine/COPYING.
+MEGAZINE_PUBLIC_KEY = ""
+
+# To use a commercial licensed flowplayer, enter your flowplayer key here
+# and add the flowplayer.commercial-3.x.x.swf file to the
+# rooibos/static/flowplayer directory
+FLOWPLAYER_KEY = ""
+
+
+# By default, video delivery links are created as symbolic links. Some
+# streaming servers (e.g. Wowza) don't deliver those, so hard links are
+# required.
+HARD_VIDEO_DELIVERY_LINKS = False
+
+
+# List of facets to permanently hide in Explore screen
+# Comparison is made on effective (shown) label
+HIDE_FACETS = ()
+# List of facets using whole expression instead of tokenized terms
+# Comparison is made on effective (shown) label
+FULL_FACETS = ()
+
+
+PREVIEW_WIDTH = 640
+PREVIEW_HEIGHT = 480
+
+
+# If the JPEGs available to MDID are not compressed properly, loading a
+# presentation may take a very long time, as a lot of large images have to be
+# transferred.  By setting this, presentation images are forces to be
+# reprocessed and compressed to the usual 85% quality
+FORCE_SLIDE_REPROCESS = False
+
+
+# If set to a list of strings, all groups with the given names are granted read
+# access on newly created presentations
+PRESENTATION_PERMISSIONS = []
+
+# Set to True if newly created presentations should be hidden
+PRESENTATION_HIDE_ON_CREATE = False
+
+# Show extra field values next to thumbnails, specify by field label
+# THUMB_EXTRA_FIELDS = ['Creator', 'Work Type']
+THUMB_EXTRA_TEMPLATE = 'ui_record_extra.html'
+THUMB_EXTRA_FIELDS = []
+
+
+# Settings that should be available in template rendering
+EXPOSE_TO_CONTEXT = (
+    'STATIC_DIR',
+    'PRIMARY_COLOR',
+    'SECONDARY_COLOR',
+    'CUSTOM_TRACKER_HTML',
+    'ADMINS',
+    'LOGO_URL',
+    'FAVICON_URL',
+    'COPYRIGHT',
+    'TITLE',
+    'SHOW_FRONTPAGE_LOGIN',
+    'MASTER_TEMPLATE',
+    'PREVIEW_WIDTH',
+    'PREVIEW_HEIGHT',
+    'SHOW_TERMS',
+    'SHIB_ENABLED',
+    'SHIB_LOGOUT_URL',
+    'HIDE_SHOWCASES',
+    'CAS_SERVER_URL',
+    'WORKS',
+)
+
+ADMINS = (
+    # ('Your name', 'your@email.example'),
+)
+
+MANAGERS = ADMINS
+
+
+GOOGLE_ANALYTICS_MODEL = True
+
+
+INSTANCE_NAME = ''
+
+
+# LDAP_AUTH = (
+#     {
+#         # LDAP Example
+#         'uri': 'ldap://ldap.example.edu',
+#         'base': 'ou=People,o=example',
+#         'cn': 'cn',
+#         'dn': 'dn',
+#         'version': 2,
+#         'scope': 1,
+#         'options': {'OPT_X_TLS_TRY': 1},
+#         'attributes': (
+#             'sn', 'mail', 'givenName', 'eduPersonPrimaryAffiliation'),
+#         'firstname': 'givenname',
+#         'lastname': 'sn',
+#         'email': 'mail',
+#         'bind_user': '',
+#         'bind_password': '',
+#         # list of groups to check for user membership;
+#         # populates virtual LDAP attribute '_groups'
+#         'groups': (),
+#     },
+# )
+IMAP_AUTH = ()
+POP_AUTH = ()
+
+SHIB_ENABLED = False
+SHIB_ATTRIBUTE_MAP = None
+SHIB_USERNAME = None
+SHIB_EMAIL = None
+SHIB_FIRST_NAME = None
+SHIB_LAST_NAME = None
+SHIB_LOGOUT_URL = None
+
+SSL_PORT = None  # ':443'
+SSL_ON = False
+
+SESSION_COOKIE_AGE = 6 * 3600  # in seconds
+
+
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
+        'LOCATION': 'memcached:11211',
+        'KEY_PREFIX': INSTANCE_NAME,
+    }
+}
+
+
+INTERNAL_IPS = ('127.0.0.1', )
+
+
+# If HELP_URL ends in / or ?, the current page id or reference will be appended
+HELP_URL = 'http://mdid.org/help/'
+
+
+# S3 settings
+S3_FOLDER_MAPPING = {}
+AWS_STORAGE_BUCKET_NAME = ''
+AWS_ACCESS_KEY = None
+AWS_SECRET_KEY = None
+
+CDN_THUMBNAILS = {}
+
+UPLOAD_LIMIT = 5 * 1024 * 1024
+
+
+CAS_SERVER_URL = None
+
+
+WWW_AUTHENTICATION_REALM = "Please log in to access media from MDID " \
+    "at Your University"
+
+
+AUTHENTICATION_BACKENDS = (
+    'django.contrib.auth.backends.ModelBackend',
+    'rooibos.auth.ldapauth.LdapAuthenticationBackend',
+    'rooibos.auth.mailauth.ImapAuthenticationBackend',
+    'rooibos.auth.mailauth.PopAuthenticationBackend',
+)
+
+
+MASTER_TEMPLATE = 'master_root.html'
+
+
+RECORD_DEFAULT_FIELDSET = 'dc'
+
+# include child collections in browse screens
+BROWSE_CHILDREN = False
+
+
+def _get_log_handler(log_dir=None):
+
+    # Can't do sys.argv since it does not exist when running under PyISAPIe
+    cmdline = getattr(sys, 'argv', [])
+    if len(cmdline) > 1:
+        # only use first command line argument for log file name
+        cmd = os.path.splitext(os.path.basename(cmdline[0]))[0]
+        cmd = re.sub(r'[^a-zA-Z0-9]', '', cmdline[1]) \
+            if cmd == 'manage' else cmd
+        basename = 'rooibos-%s' % cmd
+    else:
+        basename = 'rooibos'
+
+    if not log_dir:
+        log_dir = os.path.join(install_dir, 'log')
+
+    return {
+        'file': {
+            'class': 'logging.FileHandler',
+            'filename': os.path.join(log_dir, basename + '.log'),
+            'formatter': 'verbose',
+        },
+    }
+
+
+handler = _get_log_handler()
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'formatters': {
+        'verbose': {
+            'format': '[%(name)30.30s]%(levelname)8s %(asctime)s '
+                      '%(process)d %(message)s '
+                      '[%(filename)s:%(lineno)d]'
+        },
+        'simple': {
+            'format': '%(levelname)s %(message)s'
+        },
+    },
+    'handlers': handler,
+    'loggers': {
+        'rooibos': {
+            'handlers': [handler.keys()[0]],
+            'level': 'DEBUG',
+            'propagate': False,
+        },
+        'pika': {
+            'handlers': [handler.keys()[0]],
+            'level': 'WARNING',
+        },
+        'django': {
+            'handlers': [handler.keys()[0]],
+            'level': 'WARNING',
+        },
+        '': {
+            'handlers': [handler.keys()[0]],
+            'level': 'DEBUG',
+        },
+    },
+}

--- a/rooibos_settings/docker_template.py
+++ b/rooibos_settings/docker_template.py
@@ -1,0 +1,6 @@
+from .base import *
+
+# Override anything in base_docker.py here before renaming the file to
+# local_settings.py.
+#
+# The file can be managed using a new image, docker config, or a shared volume

--- a/solr4/.dockerignore
+++ b/solr4/.dockerignore
@@ -1,0 +1,1 @@
+Dockerfile

--- a/solr4/Dockerfile
+++ b/solr4/Dockerfile
@@ -1,0 +1,21 @@
+FROM openjdk:8-jre-alpine
+
+ADD https://archive.apache.org/dist/lucene/solr/4.10.4/solr-4.10.4.tgz /tmp/solr.tgz
+RUN mkdir /opt \
+    && cd /tmp \
+    && tar -xf solr.tgz \
+    && mv /tmp/solr-4.10.4/example /opt/solr \
+    && rm -Rf /tmp/solr-4.10.4 \
+    && rm -Rf /opt/solr/example-DIH /opt/solr/solr-webapp \
+      /opt/solr/exampledocs \
+      /opt/solr/example-schemaless /opt/solr/solr /opt/solr/multicore \
+      /opt/solr/scripts /opt/solr/*.txt
+
+COPY . /opt/solr/config
+RUN mv /opt/solr/config/template /opt/solr/config/mdid
+
+VOLUME ["/opt/solr/config/mdid/data"]
+
+EXPOSE 8983
+WORKDIR /opt/solr
+CMD ["java", "-Dsolr.solr.home=/opt/solr/config", "-jar",  "/opt/solr/start.jar"]


### PR DESCRIPTION
The various changes include support for building docker images using best practice secret protection as well as basic documentation.

After this is merged, the Docker hub organization name (wmit) should be updated to something more official (mdid or vrchost?). To keep images up to date it'd be worth considering using [automated builds](https://docs.docker.com/docker-hub/builds/#create-an-automated-build) too, but that's all for later.