### PR TITLE
Fix for 'doesn't declare an explicit app_label' messages in log

### DIFF
--- a/rooibos/access/models.py
+++ b/rooibos/access/models.py
@@ -19,6 +19,7 @@ class AccessControl(models.Model):
 
     class Meta:
         unique_together = ('content_type', 'object_id', 'user', 'usergroup')
+        app_label = 'access'
 
     def save(self, **kwargs):
         if (self.user and self.usergroup):
@@ -33,6 +34,7 @@ class AccessControl(models.Model):
                 return char.upper()
             else:
                 return '-'
+
         return '%s [%s%s%s] %s (%s)' % (
             self.user or self.usergroup or 'AnonymousUser',
             f(self.read, 'r'),
@@ -93,6 +95,9 @@ class ExtendedGroup(Group):
         ('E', 'Everybody'),
     )
 
+    class Meta:
+        app_label = 'access'
+
     type = models.CharField(max_length=1, choices=TYPE_CHOICES)
 
     objects = ExtendedGroupManager()
@@ -138,6 +143,9 @@ class Subnet(models.Model):
     def __unicode__(self):
         return '%s: %s' % (self.group.name, self.subnet)
 
+    class Meta:
+        app_label = 'access'
+
 
 class Attribute(models.Model):
     group = models.ForeignKey(ExtendedGroup, limit_choices_to={'type': 'P'})
@@ -146,10 +154,16 @@ class Attribute(models.Model):
     def __unicode__(self):
         return '%s: %s' % (self.group.name, self.attribute)
 
+    class Meta:
+        app_label = 'access'
+
 
 class AttributeValue(models.Model):
     attribute = models.ForeignKey(Attribute)
     value = models.CharField(max_length=255)
+
+    class Meta:
+        app_label = 'access'
 
 
 SEPARATOR = ' :: '

--- a/rooibos/data/models.py
+++ b/rooibos/data/models.py
@@ -42,6 +42,7 @@ class Collection(models.Model):
 
     class Meta:
         ordering = ['order', 'title']
+        app_label = 'data'
 
     def save(self, **kwargs):
         unique_slug(self, slug_source='title', slug_field='name',
@@ -106,6 +107,7 @@ class CollectionItem(models.Model):
 
     def natural_key(self):
         return self.collection.natural_key() + self.record.natural_key()
+
     natural_key.dependencies = ['data.Collection', 'data.Record']
 
     def __unicode__(self):
@@ -114,6 +116,9 @@ class CollectionItem(models.Model):
             self.collection_id,
             'hidden' if self.hidden else ''
         )
+
+    class Meta:
+        app_label = 'data'
 
 
 def _records_with_individual_acl_by_ids(ids):
@@ -138,6 +143,9 @@ class Record(models.Model):
     manager = models.CharField(max_length=50, null=True, blank=True)
     next_update = models.DateTimeField(null=True, blank=True, serialize=False)
     owner = models.ForeignKey(User, null=True, blank=True, serialize=False)
+
+    class Meta:
+        app_label = 'data'
 
     def natural_key(self):
         return (self.name,)
@@ -348,6 +356,7 @@ class Record(models.Model):
                 context_type=None,
                 hidden=False)
             return titles[0].value if titles else None
+
         return get_title() if self.id else None
 
     @property
@@ -360,6 +369,7 @@ class Record(models.Model):
                 context_type=None,
                 hidden=False)
             return identifiers[0].value if identifiers else None
+
         return get_identifier() if self.id else None
 
     @property
@@ -453,6 +463,9 @@ class MetadataStandard(models.Model):
     name = models.SlugField(max_length=50, unique=True)
     prefix = models.CharField(max_length=16, unique=True)
 
+    class Meta:
+        app_label = 'data'
+
     def natural_key(self):
         return (self.prefix,)
 
@@ -469,11 +482,15 @@ class Vocabulary(models.Model):
 
     class Meta:
         verbose_name_plural = "vocabularies"
+        app_label = 'data'
 
 
 class VocabularyTerm(models.Model):
     vocabulary = models.ForeignKey(Vocabulary)
     term = models.TextField()
+
+    class Meta:
+        app_label = 'data'
 
     def __unicode__(self):
         return self.term
@@ -498,8 +515,12 @@ class Field(models.Model):
     vocabulary = models.ForeignKey(
         Vocabulary, null=True, blank=True, serialize=False)
 
+    class Meta:
+        app_label = 'data'
+
     def natural_key(self):
         return (self.standard.prefix if self.standard else '', self.name,)
+
     natural_key.dependencies = ['data.MetadataStandard']
 
     def save(self, **kwargs):
@@ -537,6 +558,7 @@ class Field(models.Model):
         unique_together = ('name', 'standard')
         ordering = ['name']
         order_with_respect_to = 'standard'
+        app_label = 'data'
 
 
 @transaction.atomic
@@ -569,6 +591,7 @@ class FieldSet(models.Model):
 
     class Meta:
         ordering = ['title']
+        app_label = 'data'
 
     @staticmethod
     def for_user(user):
@@ -591,6 +614,7 @@ class FieldSetField(models.Model):
 
     class Meta:
         ordering = ['order']
+        app_label = 'data'
 
 
 class FieldValue(models.Model):
@@ -653,6 +677,7 @@ class FieldValue(models.Model):
         return FieldValue.BROWSE_VALUE_REGEX.sub('', value or '')[:32]
 
     class Meta:
+        app_label = 'data'
         ordering = ['order']
         index_together = [
             ['record', 'field'],
@@ -665,6 +690,10 @@ class DisplayFieldValue(FieldValue):
     """
     Represents a mapped field value for display.  Cannot be saved.
     """
+
+    class Meta:
+        app_label = 'data'
+
     def save(self, *args, **kwargs):
         raise NotImplementedError()
 

--- a/rooibos/statistics/models.py
+++ b/rooibos/statistics/models.py
@@ -16,6 +16,9 @@ class Activity(models.Model):
     event = models.CharField(max_length=64, db_index=True)
     data_field = models.TextField(blank=True, db_column='data')
 
+    class Meta:
+        app_label = 'statistics'
+
     def __unicode__(self):
         return "Activity (%s %s) %s" % (self.date, self.time, self.event)
 
@@ -73,6 +76,9 @@ class AccumulatedActivity(models.Model):
     event = models.CharField(max_length=64, db_index=True)
     final = models.BooleanField(default=False)
     count = models.IntegerField()
+
+    class Meta:
+        app_label = 'statistics'
 
     def __unicode__(self):
         return "AccumulatedActivity (%s) %s %s" % (

--- a/rooibos/storage/models.py
+++ b/rooibos/storage/models.py
@@ -55,6 +55,7 @@ class Storage(models.Model):
 
     class Meta:
         verbose_name_plural = 'storage'
+        app_label = 'storage'
 
     def save(self, **kwargs):
         unique_slug(
@@ -180,6 +181,7 @@ class Media(models.Model):
     class Meta:
         unique_together = ("record", "name")
         verbose_name_plural = "media"
+        app_label = 'storage'
 
     def __unicode__(self):
         return self.url
@@ -312,6 +314,9 @@ class Media(models.Model):
 class TrustedSubnet(models.Model):
     subnet = models.CharField(max_length=80)
 
+    class Meta:
+        app_label = 'storage'
+
     def __unicode__(self):
         return "TrustedSubnet (%s)" % self.subnet
 
@@ -324,6 +329,9 @@ class ProxyUrl(models.Model):
     user = models.ForeignKey(User)
     user_backend = models.CharField(max_length=256, null=True, blank=True)
     last_access = models.DateTimeField(null=True, blank=True)
+
+    class Meta:
+        app_label = 'storage'
 
     def __unicode__(self):
         return 'ProxyUrl %s: %s (Ctx %s, Usr %s, Sbn %s)' % (

--- a/rooibos/workers/models.py
+++ b/rooibos/workers/models.py
@@ -16,6 +16,7 @@ class JobInfo(models.Model):
 
     class Meta:
         ordering = ['completed', '-created_time']
+        app_label = 'workers'
 
     def run(self):
         try:


### PR DESCRIPTION
 theoretically helps moving to Django 1.9+ also.  